### PR TITLE
Patch OpenSSL for ARM64/M1 Macs

### DIFF
--- a/Formula/openssl@1.0.rb
+++ b/Formula/openssl@1.0.rb
@@ -6,16 +6,16 @@ class OpensslAT10 < Formula
   sha256 "ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16"
   version_scheme 1
 
-  patch do
-    url "https://gist.githubusercontent.com/felixbuenemann/5f4dcb30ebb3b86e1302e2ec305bac89/raw/b339a33ff072c9747df21e2558c36634dd62c195/openssl-1.0.2u-darwin-arm64.patch"
-    sha256 "4ad22bcfc85171a25f035b6fc47c7140752b9ed7467bb56081c76a0a3ebf1b9f"
-  end
-
   bottle do
   end
 
   keg_only :provided_by_macos,
     "openssl/libressl is provided by macOS so don't link an incompatible version"
+
+  patch do
+    url "https://gist.githubusercontent.com/felixbuenemann/5f4dcb30ebb3b86e1302e2ec305bac89/raw/b339a33ff072c9747df21e2558c36634dd62c195/openssl-1.0.2u-darwin-arm64.patch"
+    sha256 "4ad22bcfc85171a25f035b6fc47c7140752b9ed7467bb56081c76a0a3ebf1b9f"
+  end
 
   # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
   # SSLv3 & zlib are off by default with 1.1.0 but this may not

--- a/Formula/openssl@1.0.rb
+++ b/Formula/openssl@1.0.rb
@@ -6,6 +6,11 @@ class OpensslAT10 < Formula
   sha256 "ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16"
   version_scheme 1
 
+  patch do
+    url "https://gist.githubusercontent.com/felixbuenemann/5f4dcb30ebb3b86e1302e2ec305bac89/raw/b339a33ff072c9747df21e2558c36634dd62c195/openssl-1.0.2u-darwin-arm64.patch"
+    sha256 "4ad22bcfc85171a25f035b6fc47c7140752b9ed7467bb56081c76a0a3ebf1b9f"
+  end
+
   bottle do
   end
 
@@ -37,7 +42,7 @@ class OpensslAT10 < Formula
     # Whilst our env points to opt_bin, by default OpenSSL resolves the symlink.
     ENV["PERL"] = Formula["perl"].opt_bin/"perl" if which("perl") == Formula["perl"].opt_bin/"perl"
 
-    arch_args = %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128]
+    arch_args = %W[darwin64-#{Hardware::CPU.arch}-cc enable-ec_nistp_64_gcc_128]
 
     ENV.deparallelize
     system "perl", "./Configure", *(configure_args + arch_args)


### PR DESCRIPTION
Fixes #2

Uses [this patch](https://gist.githubusercontent.com/felixbuenemann/5f4dcb30ebb3b86e1302e2ec305bac89/raw/b339a33ff072c9747df21e2558c36634dd62c195/openssl-1.0.2u-darwin-arm64.patch) to add ARM64 support to OpenSSL's Configure script and the Ruby constant `#{Hardware::CPU.arch}` to correctly select the current architecture (which is also used on [homebrew-core's OpenSSL formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl%401.1.rb#L92)).