### PR TITLE
Fix chntpw compile on M1

### DIFF
--- a/Formula/chntpw.rb
+++ b/Formula/chntpw.rb
@@ -8,7 +8,12 @@ class Chntpw < Formula
   depends_on "sidneys/homebrew/openssl@1.0"
 
   def install
-    system "make"
+    if Hardware::CPU.arm?
+      # Homebrew on M1 appears to install here instead of /usr/local/opt
+      system "make", "OSSLPATH=/opt/homebrew/opt/openssl@1.0"
+    else
+      system "make"
+    end
     bin.install "chntpw"
   end
 

--- a/Formula/chntpw.rb
+++ b/Formula/chntpw.rb
@@ -10,7 +10,7 @@ class Chntpw < Formula
   def install
     if Hardware::CPU.arm?
       # Homebrew on M1 appears to install here instead of /usr/local/opt
-      system "make", "OSSLPATH=/opt/homebrew/opt/openssl@1.0"
+      system "make", "OSSLPATH=#{Formula["sidneys/homebrew/openssl@1.0"].opt_prefix}"
     else
       system "make"
     end


### PR DESCRIPTION
I'm not 100% sure if this is the best solution, but it does work. Homebrew on M1 appears to use the prefix `/opt/homebrew` rather than `/usr/local/opt` used previously and hardcoded into the chntpw Makefile, leading to the following error:

```
clang: error: no such file or directory: '/usr/local/opt/openssl/lib/libcrypto.a'
```

This fix checks if the CPU is ARM, and forces the OpenSSL path to `/opt/homebrew` in chntpw if so. There might be a cleaner solution by checking the Homebrew version or something like that, but I'm not overly familiar with how that might work.