### PR TITLE
fix #9 #10

### DIFF
--- a/Casks/sourcetree-latest.rb
+++ b/Casks/sourcetree-latest.rb
@@ -7,7 +7,7 @@ cask 'sourcetree-latest' do
   name 'Atlassian Sourcetree'
   homepage 'https://www.sourcetreeapp.com/'
 
-  depends_on macos: '>= :yosemite'
+  depends_on macos: '>= :el_capitan'
 
   app 'Sourcetree.app'
   binary "#{appdir}/Sourcetree.app/Contents/Resources/stree"


### PR DESCRIPTION
fix depends_on :macos => :yosemite is deprecated

Yosemite  is removed on this release https://github.com/Homebrew/brew/releases/tag/3.5.0
See also this doc https://docs.brew.sh/Cask-Cookbook#depends_on-macos